### PR TITLE
debug to stderr

### DIFF
--- a/lib/Logger.py
+++ b/lib/Logger.py
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301 USA
 #
-import os
+import os, sys
 
 class Logger():
     def __init__ (self, debug=False, quiet=False):
@@ -29,14 +29,14 @@ class Logger():
 
     def debug(self, message):
         if self.DEBUG and not self.QUIET:
-            print "# %s" % message
+            print >> sys.stder, "# %s" % message
 
     def error(self, message):
-        print "*** %s" % message
+        print >> sys.stderr, "*** %s" % message
 
     def info(self, message):
         if not self.QUIET:
-            print message
+            print >> sys.stderr, message
 
 
 logger = Logger()


### PR DESCRIPTION
Every log output except stream information is routed in
to the stderr.

Example usages:
Standart sysadmin approach to supress debbug output is something like this:
`sudo ./rtmpSnoop.py 2>/dev/null`
Or if people want do distinguish debbug and stream output then can do something like that:
`sudo ./rtmpSnoop.py  2> >(while read line; do echo -e "\e[01;31m$line\e[0m"; done)`
