### PR TITLE
empty application name

### DIFF
--- a/lib/amfCommand.py
+++ b/lib/amfCommand.py
@@ -146,6 +146,8 @@ class amfCommands():
 
         if self.RTMP["app"]:
             line += "-a '%s' " % self.RTMP["app"]
+        else:
+            line += "-a '' "
 
         if self.RTMP["tcUrl"]:
             line += "-t '%s' " % self.RTMP["tcUrl"]


### PR DESCRIPTION
if i didn't sniff any application name, i will not send any.
rtmpdump by default try to determine app name and if not succeded
it will send his default, what is not what we want, so if have to
explicitly say we do not want him to use any.
